### PR TITLE
PR: Fix possible Sphinxify.py TypeError on import

### DIFF
--- a/docrepr/sphinxify.py
+++ b/docrepr/sphinxify.py
@@ -50,7 +50,7 @@ if os.name == 'nt':
     CACHEDIR = tempfile.gettempdir() + osp.sep + 'docrepr'
 else:
     username = to_unicode_from_fs(os.environ.get('USER'))
-    CACHEDIR = tempfile.gettempdir() + osp.sep + 'docrepr-' + username
+    CACHEDIR = tempfile.gettempdir() + osp.sep + 'docrepr-' + str(username)
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Sphinxify assumes that every non-NT OS has an environment variable "USER". This assumption is not necessarily true and the code will throw a TypeError on import if getenv returns None. An important example of an environment without a USER-variable are cron jobs.