### PR TITLE
PR: Remove dangling r in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `docrepr` renders Python docstrings in HTML. It is based on the `sphinxify`
 module developed by Tim Dumol for the Sage Notebook and the `utils.help`
-module developed for ther Spyder IDE.
+module developed for the Spyder IDE.
 
 # Rationale
 


### PR DESCRIPTION
I assume it came from either a pirate or a statistician.