### PR TITLE
Fix render_math condition

### DIFF
--- a/docrepr/conf.py
+++ b/docrepr/conf.py
@@ -21,11 +21,8 @@ sys.path.append(os.path.abspath('./sphinxext'))
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['templates']
 
-# MathJax load path (doesn't have effect for sphinx 1.0-)
+# MathJax load path
 mathjax_path = 'MathJax/MathJax.js'
-
-# JsMath load path (doesn't have effect for sphinx 1.1+)
-jsmath_path = 'easy/load.js'
 
 # The suffix of source filenames.
 source_suffix = '.rst'

--- a/docrepr/sphinxify.py
+++ b/docrepr/sphinxify.py
@@ -201,16 +201,12 @@ def init_template_vars(oinfo):
 
 def generate_extensions(render_math):
     """Generate list of Sphinx extensions"""
-    # We need jsmath to get pretty plain-text latex in docstrings
-    extensions = []
-    if sphinx.__version__ < "1.1" or not render_math:
-        extensions = ['sphinx.ext.jsmath']
-    else:
-        extensions = ['sphinx.ext.mathjax']
-
     # For scipy and matplotlib docstrings, which need this extension to
     # be rendered correctly (see Spyder Issue #1138)
-    extensions.append('sphinx.ext.autosummary')
+    extensions = ['sphinx.ext.autosummary']
+
+    if render_math:
+        extensions.append('sphinx.ext.mathjax')
 
     # Plots
     try:
@@ -251,7 +247,7 @@ def sphinxify(docstring, srcdir, output_format='html', temp_confdir=False):
     """
     if docstring is None:
         docstring = ''
-    
+
     # Rst file to sphinxify
     base_name = osp.join(srcdir, 'docstring')
     rst_name = base_name + '.rst'

--- a/docrepr/sphinxify.py
+++ b/docrepr/sphinxify.py
@@ -205,6 +205,7 @@ def generate_extensions(render_math):
     # be rendered correctly (see Spyder Issue #1138)
     extensions = ['sphinx.ext.autosummary']
 
+     # We need mathjax to get pretty plain-text latex in docstrings
     if render_math:
         extensions.append('sphinx.ext.mathjax')
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     long_description='docrepr renders Python docstrings in HTML. It is based on the sphinxify module developed by Tim Dumol for the Sage Notebook and the utils.inspector developed for ther Spyder IDE.',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=['docutils', 'jinja2', 'sphinx'],
+    install_requires=['docutils', 'jinja2', 'sphinx>=1.1'],
     url='https://github.com/spyder-ide/docrepr',
     author='Tim Dumol / The Spyder Development Team',
     maintainer='The Spyder Development Team',


### PR DESCRIPTION
Copied by @CAM-Gerlach from [the comment below](https://github.com/spyder-ide/docrepr/pull/25#discussion_r762839498)

> `if sphinx.__version__ < "1.1" or not render_math` seems to fail later if `render_math` is False: The reason is that latest sphinx versions seem to have removed jsmath, though we try to load it when `render_math` is False.

Related to #26 