### PR TITLE
Merge Sphinx build destination and source directory

### DIFF
--- a/docrepr/sphinxify.py
+++ b/docrepr/sphinxify.py
@@ -314,6 +314,9 @@ def sphinxify(docstring, srcdir, output_format='html', temp_confdir=False):
             error_message = "It was not possible to get rich help for this object"
             output = warning(error_message)
 
+        # Merge the srcdir and destdir
+        shutil.copytree(destdir, srcdir, dirs_exist_ok=True)
+
     # Remove temp confdir
     if temp_confdir:
         shutil.rmtree(confdir, ignore_errors=True)


### PR DESCRIPTION
Fixes #31 

Follow-up #21

This seems to work as intended:

![ok](https://user-images.githubusercontent.com/21197331/145792566-2f5794e7-997a-4030-9303-236a67c62779.png)

I understand that it behaves the way it used to before #21 was in, with old Sphinx versions.