### PR TITLE
Add ability to render Sphinx-format docstrings

### DIFF
--- a/docrepr/tests/test_output.py
+++ b/docrepr/tests/test_output.py
@@ -18,6 +18,53 @@ import docrepr.sphinxify as sphinxify
 
 # ---- Test data
 
+# A sample function to test
+def get_random_ingredients(kind=None):
+    """
+    Return a list of random ingredients as strings.
+
+    :param kind: Optional "kind" of ingredients.
+    :type kind: list[str] or None
+    :raise ValueError: If the kind is invalid.
+    :return: The ingredients list.
+    :rtype: list[str]
+
+    """
+    return ['eggs', 'bacon', 'spam']
+
+
+# A sample class to test
+class SpamCans(object):
+    """
+    Cans of spam.
+
+    :param n_cans: Number of cans of spam.
+    :type n_cans: int
+    :raise ValueError: If spam is negative.
+
+    """
+
+    def __init__(self, n_cans=1):
+        """Spam init."""
+        if n_cans < 0:
+            raise ValueError('Spam must be non-negative!')
+        self.n_cans = n_cans
+
+    def eat_one(self):
+        """
+        Eat one can of spam.
+
+        :raise ValueError: If we're all out of spam.
+        :return: The number of cans of spam left.
+        :rtype: int
+
+        """
+        if self.n_cans <= 0:
+            raise ValueError('All out of spam!')
+        self.n_cans -= 1
+        return self.n_cans
+
+
 PLOT_DOCSTRING = """
 .. plot::
 
@@ -42,6 +89,21 @@ TEST_CASES = {
             },
         'options': {},
         },
+    'function': {
+        'obj': get_random_ingredients,
+        'oinfo': {'name': 'get_random_ingredients'},
+        'options': {},
+        },
+    'class': {
+        'obj': SpamCans,
+        'oinfo': {'name': 'SpamCans'},
+        'options': {},
+        },
+    'method': {
+        'obj': SpamCans().eat_one,
+        'oinfo': {'name': 'SpamCans.eat_one'},
+        'options': {},
+        },
     'render_math': {
         'obj': None,
         'oinfo': {
@@ -57,6 +119,11 @@ TEST_CASES = {
             'docstring': 'This is a rational number :math:`\\frac{x}{y}`',
             },
         'options': {'render_math': False},
+        },
+    'numpy_module': {
+        'obj': np,
+        'oinfo': {'name': 'NumPy'},
+        'options': {},
         },
     'numpy_sin': {
         'obj': np.sin,

--- a/docrepr/tests/test_output.py
+++ b/docrepr/tests/test_output.py
@@ -30,11 +30,13 @@ def get_random_ingredients(kind=None):
     :rtype: list[str]
 
     """
+    if 'spam' in kind:
+        return ['spam', 'spam', 'eggs', 'spam']
     return ['eggs', 'bacon', 'spam']
 
 
 # A sample class to test
-class SpamCans(object):
+class SpamCans:
     """
     Cans of spam.
 
@@ -89,17 +91,17 @@ TEST_CASES = {
             },
         'options': {},
         },
-    'function': {
+    'function_sphinx': {
         'obj': get_random_ingredients,
         'oinfo': {'name': 'get_random_ingredients'},
         'options': {},
         },
-    'class': {
+    'class_sphinx': {
         'obj': SpamCans,
         'oinfo': {'name': 'SpamCans'},
         'options': {},
         },
-    'method': {
+    'method_sphinx': {
         'obj': SpamCans().eat_one,
         'oinfo': {'name': 'SpamCans.eat_one'},
         'options': {},


### PR DESCRIPTION
As originally reported by @fasiha , currently docrepr doesn't have special handling to wrap Sphinx-format docstrings into the appropriate `:py:<type>::` directive, so they are rendered as intended. This PR is a first stab at doing so, by just using some simple hueristics to detect them, and wrapping them as needed with the appropriate arguments; otherwise, it leaves non-Sphinx format docstrings (Numpydoc, etc) alone.

There are some potential edge cases this might not handle, and it would be nice to implement a much better layout and style (e.g. like we currently do for Numpydoc), but this seems to be a good starting point to iterate on. My main concern is if we should be hacking our own here, or there is a better way to do this by co-opting some existing functionality from somewhere—I don't want to re-invent the wheel here, though for this relatively simple case it might be worth it versus working around a lot of potentially unrelated Sphinx-Autodoc functionality.

Here's the rendered example from #34 :

![image](https://user-images.githubusercontent.com/17051931/149434040-672e7e16-9e91-4d0a-911a-9bb57c6335b9.png)

You can test it yourself by cloning my fork and running in the root:

```bash
pytest -k function --open-browser
```

Fixes #34 

CC: @martinRenou @fasiha 