### PR TITLE
PR: Handle merging directories containing same-named read-only files

### DIFF
--- a/docrepr/utils.py
+++ b/docrepr/utils.py
@@ -50,7 +50,11 @@ def merge_directories(source, destination):
     """Merge a source into a dest dir; compat shim for Python <3.8."""
     try:
         shutil.copytree(source, destination, dirs_exist_ok=True)
-    except TypeError:
+    except (TypeError, shutil.Error):
+        # XXX: Also handle shutil.Error, which can occur when
+        # shutil.copytree attempts to merge directories containing
+        # same-named read-only files.  This case is correctly handled
+        # by the manual copy routine below.
         pass
     else:
         return


### PR DESCRIPTION
Fixes #54.

* docrepr/utils.py (merge_directories): Also handle 'shutil.Error'
exceptions.

<!--
## Visual changes

If this PR has an impact on the rendered output, you can ask the bot to
update the reference screenshots for the visual regression tests by
commenting the following:

"Please update reference screenshots"
-->
