### PR TITLE
fix tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CHANGELOG.md
 include LICENSE.txt
 include README.md
 include conftest.py
+include pytest.ini
 recursive-include docrepr/static *.*
 recursive-include docrepr/js *.*
 recursive-include docrepr/templates *.*

--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 # Third party imports
 import pytest
+import pytest_asyncio
 from PIL import Image, ImageChops
 
 # ---- Constants
@@ -64,7 +65,7 @@ def open_browser(request):
     return _open_browser
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def compare_screenshots(request):
     """Run visual regression test on the output."""
     async def _compare_screenshots(test_id, url):

--- a/docrepr/tests/test_output.py
+++ b/docrepr/tests/test_output.py
@@ -195,7 +195,7 @@ def fixture_build_oinfo():
         if obj is not None:
             oinfo = Inspector().info(obj)
         else:
-            oinfo = object_info()
+            oinfo = object_info(name=None, found=None)
         oinfo = {**oinfo, **oinfo_data}
         return oinfo
     return _build_oinfo

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,4 @@ minversion = 6.0
 testpaths =
     docrepr/tests
 xfail_strict = True
+asyncio_default_fixture_loop_scope = function

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ project_urls =
     Parent Project = https://www.spyder-ide.org/
 
 [options]
-packages = find:
+packages = find_namespace:
 install_requires =
     docutils
     jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,6 +61,7 @@ test =
     ipython
     matplotlib>=2.2.4
     numpy
+    pillow
     pytest>=6.0.0
     pytest-asyncio
 visual_test =


### PR DESCRIPTION
I tried to package this for inclusion in nixpkgs and noticed that all of the tests are currently broken.

This PR fixes the tests (and some deprecation warnings).

Each commit explained:

- add missing test dependency on PIL

    PIL is currently imported in conftest.py, so it is required for running tests.

- add @pytest_asyncio.fixture

    ```
    TypeError: 'coroutine' object is not callable
    PytestDeprecationWarning: asyncio test 'test_sphinxify[...]' requested async @pytest.fixture 'compare_screenshots' in strict mode. You might want to use @pytest_asyncio.fixture or switch to auto mode. This will become an error in future versions of flake8-asyncio.
    ```

    It seems that pytest-asyncio changed its default behavior at some point.

- fix object_info() missing 2 required keyword-only arguments

    ```
    TypeError: object_info() missing 2 required keyword-only arguments: 'name' and 'found'
    ```

    It seems to me that `object_info` is/was an undocumented function in `IPython`. It was changed in commit https://github.com/ipython/ipython/commit/30ae096c778779165376af90e04319cc1123d35e to explicitly require some of the kwargs. Looking at the code, they used to be automatically set to `None` when not provided, so that's what I did in this commit.

-  make the asyncio fixture scope explicit

    ```
    PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
    The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"
    ```

    I think the exact scope doesn't matter too much in this case, so I set it to `function` to match the future default.

-  treat docrepr/{js,static,templates} as namespace packages

    <details>

    ```
    _Warning: Package 'docrepr.js' is absent from the `packages` configuration.
    !!

            ********************************************************************************
            ############################
            # Package would be ignored #
            ############################
            Python recognizes 'docrepr.js' as an importable package[^1],
            but it is absent from setuptools' `packages` configuration.

            This leads to an ambiguous overall configuration. If you want to distribute this
            package, please make sure that 'docrepr.js' is explicitly added
            to the `packages` configuration field.

            Alternatively, you can also rely on setuptools' discovery methods
            (for example by using `find_namespace_packages(...)`/`find_namespace:`
            instead of `find_packages(...)`/`find:`).

            You can read more about "package discovery" on setuptools documentation page:

            - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

            If you don't want 'docrepr.js' to be distributed and are
            already explicitly excluding 'docrepr.js' via
            `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
            you can try to use `exclude_package_data`, or `include-package-data=False` in
            combination with a more fine grained `package-data` configuration.

            You can read more about "package data files" on setuptools documentation page:

            - https://setuptools.pypa.io/en/latest/userguide/datafiles.html


            [^1]: For Python, any directory (with suitable naming) can be imported,
                  even if it does not contain any `.py` files.
                  On the other hand, currently there is no concept of package data
                  directory, all directories are treated like packages.
            ********************************************************************************

    !!
    ```

    </details>

    Modern setuptools is a bit anal about trying to ship data files with your project, so it wants you to declare those directories as "namespace packages".

- include pytest.ini in source distribution

    Otherwise, attempting to run `pytest` after building from the sdist uses the default settings.